### PR TITLE
feat: migrate AI service to Google Gemini

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,13 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@langchain/core": "^0.3.30",
-        "@langchain/openai": "^0.3.17",
+        "@langchain/google-genai": "^0.2.16",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "axios": "^1.7.9",
         "dotenv": "^16.4.7",
-        "langchain": "^0.3.11",
-        "openai": "^4.78.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "zod": "^3.24.1"
@@ -869,6 +867,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1554,9 +1561,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.30.tgz",
-      "integrity": "sha512-HFUpjJ6FkPSSeLKzCLKxba4VN1DKnrXRmjaWHDb5KUyE9DZrqak3Sh6k2dkzXDJIcdd/uNeeQGFyQnubVEMkPw==",
+      "version": "0.3.72",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.72.tgz",
+      "integrity": "sha512-WsGWVZYnlKffj2eEfDocPNiaTRoxyYiLSQdQ7oxZvxGZBqo/90vpjbC33UGK1uPNBM4kT+pkdaol/MnvKUh8TQ==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -1564,12 +1571,12 @@
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.2.8",
+        "langsmith": "^0.3.46",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",
         "uuid": "^10.0.0",
-        "zod": "^3.22.4",
+        "zod": "^3.25.32",
         "zod-to-json-schema": "^3.22.3"
       },
       "engines": {
@@ -1600,37 +1607,68 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/openai": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.3.17.tgz",
-      "integrity": "sha512-uw4po32OKptVjq+CYHrumgbfh4NuD7LqyE+ZgqY9I/LrLc6bHLMc+sisHmI17vgek0K/yqtarI0alPJbzrwyag==",
+    "node_modules/@langchain/core/node_modules/langsmith": {
+      "version": "0.3.63",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.63.tgz",
+      "integrity": "sha512-GrioB7LOUksKIYsdYbBUwyD3ezy+OAQ5eu5vebytMsX3wT0xfW4rbM+vHqCY7RgZwUYLR/RlpuC18pdO+NqugA==",
       "license": "MIT",
       "dependencies": {
-        "js-tiktoken": "^1.0.12",
-        "openai": "^4.77.0",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=18"
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.3.29 <0.4.0"
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@langchain/textsplitters": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.1.0.tgz",
-      "integrity": "sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==",
+    "node_modules/@langchain/google-genai": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.2.16.tgz",
+      "integrity": "sha512-7xgQfZtn4EcKL7HYV7c5ZZUTjzjY0eh1Ex2570uwEBIUlyP5GFYeRe7gizx6965DYu6rktkXRMHaU0CuOXxAXQ==",
       "license": "MIT",
       "dependencies": {
-        "js-tiktoken": "^1.0.12"
+        "@google/generative-ai": "^0.24.0",
+        "uuid": "^11.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.2.21 <0.4.0"
+        "@langchain/core": ">=0.3.58 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/google-genai/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@ljharb/through": {
@@ -2225,6 +2263,7 @@
       "version": "20.17.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
       "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -2235,6 +2274,8 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -2717,6 +2758,8 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -2778,6 +2821,8 @@
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -2941,6 +2986,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -3736,6 +3782,15 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
       "license": "MIT"
+    },
+    "node_modules/console-table-printer": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
+      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
+      "license": "MIT",
+      "dependencies": {
+        "simple-wcswidth": "^1.0.1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -4548,6 +4603,8 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5033,13 +5090,17 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
       "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.3"
@@ -5401,6 +5462,8 @@
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -6575,6 +6638,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6657,15 +6721,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonpointer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6684,125 +6739,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/langchain": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.11.tgz",
-      "integrity": "sha512-PgAG4ZLeuSRkKsyf98cmWGdwKv3I1hOFC8a4fr7e+bm7E+F6Fx6xUkgbuC78ff0N/Cjs5BBryZIFMrqoKPqsvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@langchain/openai": ">=0.1.0 <0.4.0",
-        "@langchain/textsplitters": ">=0.0.0 <0.2.0",
-        "js-tiktoken": "^1.0.12",
-        "js-yaml": "^4.1.0",
-        "jsonpointer": "^5.0.1",
-        "langsmith": "^0.2.8",
-        "openapi-types": "^12.1.3",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "yaml": "^2.2.1",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/anthropic": "*",
-        "@langchain/aws": "*",
-        "@langchain/cerebras": "*",
-        "@langchain/cohere": "*",
-        "@langchain/core": ">=0.2.21 <0.4.0",
-        "@langchain/google-genai": "*",
-        "@langchain/google-vertexai": "*",
-        "@langchain/google-vertexai-web": "*",
-        "@langchain/groq": "*",
-        "@langchain/mistralai": "*",
-        "@langchain/ollama": "*",
-        "axios": "*",
-        "cheerio": "*",
-        "handlebars": "^4.7.8",
-        "peggy": "^3.0.2",
-        "typeorm": "*"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/anthropic": {
-          "optional": true
-        },
-        "@langchain/aws": {
-          "optional": true
-        },
-        "@langchain/cerebras": {
-          "optional": true
-        },
-        "@langchain/cohere": {
-          "optional": true
-        },
-        "@langchain/google-genai": {
-          "optional": true
-        },
-        "@langchain/google-vertexai": {
-          "optional": true
-        },
-        "@langchain/google-vertexai-web": {
-          "optional": true
-        },
-        "@langchain/groq": {
-          "optional": true
-        },
-        "@langchain/mistralai": {
-          "optional": true
-        },
-        "@langchain/ollama": {
-          "optional": true
-        },
-        "axios": {
-          "optional": true
-        },
-        "cheerio": {
-          "optional": true
-        },
-        "handlebars": {
-          "optional": true
-        },
-        "peggy": {
-          "optional": true
-        },
-        "typeorm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/langsmith": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.2.15.tgz",
-      "integrity": "sha512-homtJU41iitqIZVuuLW7iarCzD4f39KcfP9RTBWav9jifhrsDa1Ez89Ejr+4qi72iuBu8Y5xykchsGVgiEZ93w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "commander": "^10.0.1",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/langsmith/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/leven": {
@@ -7223,6 +7159,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -7358,6 +7296,8 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.78.1.tgz",
       "integrity": "sha512-drt0lHZBd2lMyORckOXFPQTmnGLWSLt8VK0W9BhOKWpMFBEoHMoz5gxMPmVq5icp+sOrsbMnsmZTVHUlKvD1Ow==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -7384,6 +7324,8 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.70.tgz",
       "integrity": "sha512-RE+K0+KZoEpDUbGGctnGdkrLFwi1eYKTlIHNl2Um98mUkGsm1u2Ff6Ltd0e8DktTtC98uy7rSj+hO8t/QuLoVQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -7392,13 +7334,9 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
-    },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -8578,6 +8516,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -9407,6 +9351,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -9567,6 +9512,8 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -9792,18 +9739,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -9857,9 +9792,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,15 +21,13 @@
   },
   "dependencies": {
     "@langchain/core": "^0.3.30",
-    "@langchain/openai": "^0.3.17",
+    "@langchain/google-genai": "^0.2.16",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "axios": "^1.7.9",
     "dotenv": "^16.4.7",
-    "langchain": "^0.3.11",
-    "openai": "^4.78.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^3.24.1"

--- a/src/ai/ai.controller.spec.ts
+++ b/src/ai/ai.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AiController } from './ai.controller';
+import { AiService } from './ai.service';
 
 describe('AiController', () => {
   let controller: AiController;
@@ -7,6 +8,12 @@ describe('AiController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AiController],
+      providers: [
+        {
+          provide: AiService,
+          useValue: { generateResponse: jest.fn() },
+        },
+      ],
     }).compile();
 
     controller = module.get<AiController>(AiController);

--- a/src/ai/ai.service.spec.ts
+++ b/src/ai/ai.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AiService } from './ai.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('AiService', () => {
   let service: AiService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AiService],
+      providers: [
+        AiService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('test-key') },
+        },
+      ],
     }).compile();
 
     service = module.get<AiService>(AiService);

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -1,19 +1,19 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ChatOpenAI } from '@langchain/openai';
+import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 
 @Injectable()
 export class AiService {
   private readonly logger = new Logger(AiService.name);
-  private readonly chatModel: ChatOpenAI;
+  private readonly chatModel: ChatGoogleGenerativeAI;
 
   constructor(private configService: ConfigService) {
-    this.chatModel = new ChatOpenAI({
-      openAIApiKey: this.configService.get<string>('OPENAI_API_KEY'),
+    this.chatModel = new ChatGoogleGenerativeAI({
+      apiKey: this.configService.get<string>('GOOGLE_API_KEY'),
       temperature: 0.7,
-      modelName: 'gpt-4-0125-preview',
-      maxTokens: 1000,
+      model: 'gemini-1.5-pro-latest',
+      maxOutputTokens: 1000,
       streaming: false,
       callbacks: [
         {
@@ -31,7 +31,6 @@ export class AiService {
           },
         },
       ],
-      timeout: 30000,
       maxRetries: 3,
     });
   }

--- a/src/messenger/messenger.controller.spec.ts
+++ b/src/messenger/messenger.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MessengerController } from './messenger.controller';
+import { MessengerService } from './messenger.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('MessengerController', () => {
   let controller: MessengerController;
@@ -7,6 +9,10 @@ describe('MessengerController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MessengerController],
+      providers: [
+        { provide: MessengerService, useValue: { handleMessage: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
     }).compile();
 
     controller = module.get<MessengerController>(MessengerController);

--- a/src/messenger/messenger.service.spec.ts
+++ b/src/messenger/messenger.service.spec.ts
@@ -1,12 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MessengerService } from './messenger.service';
+import { ConfigService } from '@nestjs/config';
+import { AiService } from '../ai/ai.service';
 
 describe('MessengerService', () => {
   let service: MessengerService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MessengerService],
+      providers: [
+        MessengerService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: AiService, useValue: { generateResponse: jest.fn() } },
+      ],
     }).compile();
 
     service = module.get<MessengerService>(MessengerService);


### PR DESCRIPTION
## Summary
- replace OpenAI chat model with Google Gemini using LangChain
- add `@langchain/google-genai` dependency and remove OpenAI packages
- mock required dependencies in unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9d6b3b6388323841b126a1f93896e